### PR TITLE
Update the version of rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1"
 bincode2 = "2.0.1"
 hkdf = "0.10"
 hpke = "0.5.0"
-rand = "0.7"
+rand = "0.8.3"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_repr = "0.1"
 


### PR DESCRIPTION
Since currently odoh-rs doesn't compile, updating the version of rand
solves it.

```
   Compiling serde v1.0.125
   Compiling bincode2 v2.0.1
   Compiling odoh-rs v0.1.10 (/home/haxxpop/cf-repos/odoh-rs)
error[E0277]: the trait bound `StdRng: rand_core::CryptoRng` is not satisfied
   --> src/protocol.rs:355:9
    |
355 |         &mut csprng,
    |         ^^^^^^^^^^^ the trait `rand_core::CryptoRng` is not implemented for `StdRng`
    | 
   ::: /home/haxxpop/.cargo/registry/src/github.com-1ecc6299db9ec823/hpke-0.5.1/src/setup.rs:141:8
    |
141 |     R: CryptoRng + RngCore,
    |        --------- required by this bound in `setup_sender`

error[E0277]: the trait bound `StdRng: rand_core::RngCore` is not satisfied
   --> src/protocol.rs:355:9
    |
355 |         &mut csprng,
    |         ^^^^^^^^^^^ the trait `rand_core::RngCore` is not implemented for `StdRng`
    | 
   ::: /home/haxxpop/.cargo/registry/src/github.com-1ecc6299db9ec823/hpke-0.5.1/src/setup.rs:141:20
    |
141 |     R: CryptoRng + RngCore,
    |                    ------- required by this bound in `setup_sender`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0277`.
error: could not compile `odoh-rs`

To learn more, run the command again with --verbose.
```