### PR TITLE
Pin HPKE version to match current version in 1.1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odoh-rs"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Tanya Verma <tverma@cloudflare.com>"]
 edition = "2018"
 license = "BSD-2-Clause"
@@ -14,8 +14,8 @@ aes-gcm = "0.8"
 anyhow = "1"
 bincode2 = "2.0.1"
 hkdf = "0.10"
-hpke = "0.5.0"
-rand = "0.8.3"
+hpke = "=0.5.0"
+rand = "0.7"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_repr = "0.1"
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -45,7 +45,7 @@ const AEAD_KEY_SIZE: usize = 16;
 const AEAD_NONCE_SIZE: usize = 12;
 const AEAD_TAG_SIZE: usize = 16;
 /// This is the maximum of `AEAD_KEY_SIZE` and `AEAD_NONCE_SIZE`
-const RESPONSE_NONCE_SIZE: usize = 16;
+pub const RESPONSE_NONCE_SIZE: usize = 16;
 
 macro_rules! impl_custom_serde {
     ($name:ident) => {


### PR DESCRIPTION
Currently, the HPKE version in 1.1.1.1 is pinned to `0.5.0`. I'm pinning this as well to prevent the build from failing and ensuring compat with 1.1.1.1 until @xofyarg and @vavrusa decide to update the library and the target in 1.1.1.1.

Also exporting response nonce size.