### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ keywords = ["odoh", "protocols", "dns", "doh", "privacy"]
 categories = ["network-programming", "cryptography"]
 
 [dependencies]
-aes-gcm = { version = "0.8", features = [ "std" ] }
+aes-gcm = { version = "0.9", features = [ "std" ] }
 bytes = "1.0"
-hkdf = "0.10"
-hpke = { version = "0.5.1", features = [ "std" ] }
+hkdf = "0.11"
+hpke = { version = "0.6", features = [ "std" ] }
 rand = { version = "0.8", features = [ "std_rng" ], default-features = false }
 thiserror = "1.0"
 


### PR DESCRIPTION
I'm just going through crates my project depends on, trying to update dependencies where possible, to reduce the number of redundant versions of the same crate in my build tree. Feel free to decline or push back if this is unwelcome :) I've run cargo test and clippy.