### PR TITLE
Upgraded HPKE dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "cryptography"]
 aes-gcm = { version = "0.8", features = [ "std" ] }
 bytes = "1.0"
 hkdf = "0.10"
-hpke = { version = "0.5.1", features = [ "std" ] }
+hpke = { version = "0.8", features = [ "std", "x25519" ], default-features = false }
 rand = { version = "0.8", features = [ "std_rng" ], default-features = false }
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 anyhow = "1"
-clap = "3.0.0-beta.2"
+clap = { version = "3.0.0-rc.0", features = ["derive"] }
 criterion = "0.3"
 domain = "0.5"
 env_logger = "0.8"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,7 +1,7 @@
 // A basic client example.
 
 use anyhow::{Context, Result};
-use clap::{crate_version, Clap};
+use clap::Parser;
 use domain::base::{Dname as DnameO, Message, MessageBuilder, ParsedDname, Rtype};
 use domain::rdata::AllRecordData;
 use log::{info, trace};
@@ -14,8 +14,8 @@ type Dname = DnameO<Vec<u8>>;
 
 const WELL_KNOWN_CONF_PATH: &str = "/.well-known/odohconfigs";
 
-#[derive(Clap, Debug)]
-#[clap(version = crate_version!())]
+#[derive(Parser, Debug)]
+#[clap(version)]
 struct Opts {
     #[clap(short, long, default_value = "cloudflare.com")]
     domain: Dname,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -7,13 +7,10 @@ use aes_gcm::aead::{AeadInPlace, NewAead};
 use aes_gcm::Aes128Gcm;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use hkdf::Hkdf;
-use hpke::aead::{AeadTag, AesGcm128};
+use hpke::aead::{Aead as AeadTrait, AesGcm128};
 use hpke::kdf::{HkdfSha256, Kdf as KdfTrait};
 use hpke::kem::X25519HkdfSha256;
-use hpke::kex::KeyExchange;
-use hpke::{
-    Deserializable, EncappedKey, HpkeError, Kem as KemTrait, OpModeR, OpModeS, Serializable,
-};
+use hpke::{Deserializable, HpkeError, Kem as KemTrait, OpModeR, OpModeS, Serializable};
 use rand::{CryptoRng, RngCore};
 use std::convert::{TryFrom, TryInto};
 use thiserror::Error as ThisError;
@@ -25,27 +22,24 @@ const LABEL_NONCE: &[u8] = b"odoh nonce";
 const LABEL_KEY_ID: &[u8] = b"odoh key id";
 const LABEL_RESPONSE: &[u8] = b"odoh response";
 
-// Identifier this crate supports.
-const KEM_ID: u16 = 0x0020;
-const KDF_ID: u16 = 0x0001;
-const AEAD_ID: u16 = 0x0001;
+// The fixed HPKE ciphersuite this crate supports, and their associated constants
+type Kem = X25519HkdfSha256;
+type Aead = AesGcm128;
+type Kdf = HkdfSha256;
+const KEM_ID: u16 = Kem::KEM_ID;
+const KDF_ID: u16 = Kdf::KDF_ID;
+const AEAD_ID: u16 = Aead::AEAD_ID;
 
 /// For the selected KDF: SHA256
 const KDF_OUTPUT_SIZE: usize = 32;
 const AEAD_KEY_SIZE: usize = 16;
 const AEAD_NONCE_SIZE: usize = 12;
-const AEAD_TAG_SIZE: usize = 16;
 
 /// This is the maximum of `AEAD_KEY_SIZE` and `AEAD_NONCE_SIZE`
 const RESPONSE_NONCE_SIZE: usize = 16;
 
 /// Length of public key used in config
 const PUBLIC_KEY_SIZE: usize = 32;
-
-type Kem = X25519HkdfSha256;
-type Aead = AesGcm128;
-type Kdf = HkdfSha256;
-type Kex = <Kem as KemTrait>::Kex;
 
 type AeadKey = [u8; AEAD_KEY_SIZE];
 type AeadNonce = [u8; AEAD_NONCE_SIZE];
@@ -87,10 +81,9 @@ pub enum Error {
     #[error("Response nonce is not equal to max(key, nonce) size")]
     InvalidResponseNonceLength,
 
-    // HpkeError doesn't support Eq
     /// Errors from hpke crate.
     #[error(transparent)]
-    Hpke(#[from] HpkeErrorWrapper),
+    Hpke(#[from] HpkeError),
 
     /// Errors from aes-gcm crate.
     #[error(transparent)]
@@ -99,12 +92,6 @@ pub enum Error {
     /// Unexpected internal error.
     #[error("Unexpected internal error")]
     Internal,
-}
-
-impl From<HpkeError> for Error {
-    fn from(e: HpkeError) -> Self {
-        Self::Hpke(HpkeErrorWrapper(e))
-    }
 }
 
 /// This is a wrapper for HpkeError, as the type doesn't support Eq.
@@ -316,7 +303,7 @@ impl ObliviousDoHConfigContents {
         let prk = Hkdf::<<Kdf as KdfTrait>::HashImpl>::new(None, &buf);
         let mut key_id = [0; KDF_OUTPUT_SIZE];
         prk.expand(&key_id_info, &mut key_id)
-            .map_err(|_| Error::from(HpkeError::InvalidKdfLength))?;
+            .map_err(|_| Error::from(HpkeError::KdfOutputTooLong))?;
         Ok(key_id.to_vec())
     }
 
@@ -498,7 +485,7 @@ impl Serialize for &ObliviousDoHMessagePlaintext {
 /// required by the target resolver to process DNS queries.
 #[derive(Clone)]
 pub struct ObliviousDoHKeyPair {
-    private_key: <Kex as KeyExchange>::PrivateKey,
+    private_key: <Kem as KemTrait>::PrivateKey,
     public_key: ObliviousDoHConfigContents,
 }
 
@@ -536,7 +523,7 @@ impl ObliviousDoHKeyPair {
     }
 
     /// Return a reference of the private key.
-    pub fn private(&self) -> &<Kex as KeyExchange>::PrivateKey {
+    pub fn private(&self) -> &<Kem as KemTrait>::PrivateKey {
         &self.private_key
     }
 
@@ -553,23 +540,19 @@ pub fn encrypt_query<R: RngCore + CryptoRng>(
     config: &ObliviousDoHConfigContents,
     rng: &mut R,
 ) -> Result<(ObliviousDoHMessage, OdohSecret)> {
-    let server_pk =
-        <Kex as KeyExchange>::PublicKey::from_bytes(&config.public_key).map_err(Error::from)?;
+    let server_pk = <Kem as KemTrait>::PublicKey::from_bytes(&config.public_key)?;
     let (encapped_key, mut send_ctx) =
-        hpke::setup_sender::<Aead, Kdf, Kem, _>(&OpModeS::Base, &server_pk, LABEL_QUERY, rng)
-            .map_err(Error::from)?;
+        hpke::setup_sender::<Aead, Kdf, Kem, _>(&OpModeS::Base, &server_pk, LABEL_QUERY, rng)?;
 
     let key_id = config.identifier()?;
     let aad = build_aad(ObliviousDoHMessageType::Query, &key_id)?;
 
     let mut odoh_secret = OdohSecret::default();
-    send_ctx
-        .export(LABEL_RESPONSE, &mut odoh_secret)
-        .map_err(Error::from)?;
+    send_ctx.export(LABEL_RESPONSE, &mut odoh_secret)?;
 
     let mut buf = compose(query)?;
 
-    let tag = send_ctx.seal(&mut buf, &aad).map_err(Error::from)?;
+    let tag = send_ctx.seal_in_place_detached(&mut buf, &aad)?;
 
     let result = [
         encapped_key.to_bytes().as_slice(),
@@ -608,9 +591,7 @@ pub fn decrypt_response(
 
     let aad = build_aad(ObliviousDoHMessageType::Response, &response.key_id)?;
 
-    cipher
-        .decrypt_in_place(GenericArray::from_slice(&nonce), &aad, &mut data)
-        .map_err(Error::from)?;
+    cipher.decrypt_in_place(GenericArray::from_slice(&nonce), &aad, &mut data)?;
 
     let response_decrypted = parse(&mut Bytes::from(data))?;
     Ok(response_decrypted)
@@ -633,35 +614,24 @@ pub fn decrypt_query(
     }
 
     let server_sk = key_pair.private();
-    let key_size = <Kex as KeyExchange>::PublicKey::size();
+    let key_size = <Kem as KemTrait>::PublicKey::size();
     let (enc, ct) = query.encrypted_msg.split_at(key_size);
 
-    let encapped_key = EncappedKey::<Kex>::from_bytes(enc).map_err(Error::from)?;
+    let encapped_key = <Kem as KemTrait>::EncappedKey::from_bytes(enc)?;
 
     let mut recv_ctx = hpke::setup_receiver::<Aead, Kdf, Kem>(
         &OpModeR::Base,
-        &server_sk,
+        server_sk,
         &encapped_key,
         LABEL_QUERY,
-    )
-    .map_err(Error::from)?;
+    )?;
 
+    // Open the payload
     let aad = build_aad(ObliviousDoHMessageType::Query, &key_id)?;
-
-    let (ciphertext, tag_bytes) = ct.split_at(ct.len() - AEAD_TAG_SIZE);
-    let mut ciphertext_copy = ciphertext.to_vec();
-    let tag = AeadTag::<Aead>::from_bytes(tag_bytes).map_err(Error::from)?;
-
-    recv_ctx
-        .open(&mut ciphertext_copy, &aad, &tag)
-        .map_err(Error::from)?;
+    let plaintext = recv_ctx.open(ct, &aad)?;
 
     let mut odoh_secret = OdohSecret::default();
-    recv_ctx
-        .export(LABEL_RESPONSE, &mut odoh_secret)
-        .map_err(Error::from)?;
-
-    let plaintext = ciphertext_copy;
+    recv_ctx.export(LABEL_RESPONSE, &mut odoh_secret)?;
 
     let query_decrypted = parse(&mut Bytes::from(plaintext))?;
     Ok((query_decrypted, odoh_secret))
@@ -680,9 +650,7 @@ pub fn encrypt_response(
 
     let mut buf = Vec::new();
     response.serialize(&mut buf)?;
-    cipher
-        .encrypt_in_place(GenericArray::from_slice(&nonce), &aad, &mut buf)
-        .map_err(Error::from)?;
+    cipher.encrypt_in_place(GenericArray::from_slice(&nonce), &aad, &mut buf)?;
 
     Ok(ObliviousDoHMessage {
         msg_type: ObliviousDoHMessageType::Response,
@@ -718,13 +686,13 @@ fn derive_secrets(
     let mut key = AeadKey::default();
     h_key
         .expand(LABEL_KEY, &mut key)
-        .map_err(|_| Error::from(HpkeError::InvalidKdfLength))?;
+        .map_err(|_| Error::from(HpkeError::KdfOutputTooLong))?;
 
     let h_nonce = Hkdf::<<Kdf as KdfTrait>::HashImpl>::new(Some(&salt), &odoh_secret);
     let mut nonce = AeadNonce::default();
     h_nonce
         .expand(LABEL_NONCE, &mut nonce)
-        .map_err(|_| Error::from(HpkeError::InvalidKdfLength))?;
+        .map_err(|_| Error::from(HpkeError::KdfOutputTooLong))?;
 
     Ok((key, nonce))
 }
@@ -762,7 +730,7 @@ mod tests {
         assert_eq!(supported[0], c2);
 
         c2.version = 0xff;
-        let supported = ObliviousDoHConfigs::from(vec![c1.clone(), c2.clone()]).supported();
+        let supported = ObliviousDoHConfigs::from(vec![c1, c2]).supported();
         assert!(supported.is_empty());
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -94,24 +94,6 @@ pub enum Error {
     Internal,
 }
 
-/// This is a wrapper for HpkeError, as the type doesn't support Eq.
-#[derive(Debug, Clone)]
-pub struct HpkeErrorWrapper(HpkeError);
-
-impl std::error::Error for HpkeErrorWrapper {}
-
-impl core::fmt::Display for HpkeErrorWrapper {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-impl PartialEq for HpkeErrorWrapper {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.to_string() == other.0.to_string()
-    }
-}
-impl Eq for HpkeErrorWrapper {}
-
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Serialize to IETF wireformat that is similar to [XDR](https://tools.ietf.org/html/rfc1014)


### PR DESCRIPTION
Just cut a new version of HPKE. It's a slightly different API, and one that's a lot simpler imo (also more extensible if PQ KEMs ever get introduced). One change is that it now adheres to the AEAD message encoding requirement, i.e., `seal()` and `open()` should return and accept single messages respectively.

The only problem you might run into is that `examples/cli.rs` doesn't compile right now. I had to test by moving the file first. It's got something to do with `clap`.