### PR TITLE
Fix CLI example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ domain = "0.5"
 env_logger = "0.8"
 hex = "0.4"
 log = "0.4"
+rand = "0.8"
 reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = [ "full" ] }
-rand = { version = "0.8", features = [ "std_rng", "getrandom" ], default-features = false }
 
 [[bench]]
 name = "odoh_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = [ "full" ] }
+rand = { version = "0.8", features = [ "std_rng", "getrandom" ], default-features = false }
 
 [[bench]]
 name = "odoh_bench"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -6,8 +6,8 @@ use domain::base::{Dname as DnameO, Message, MessageBuilder, ParsedDname, Rtype}
 use domain::rdata::AllRecordData;
 use log::{info, trace};
 use odoh_rs::*;
+use rand::prelude::*;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
 use reqwest::{Client, Url};
 
 type Dname = DnameO<Vec<u8>>;

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -6,8 +6,8 @@ use domain::base::{Dname as DnameO, Message, MessageBuilder, ParsedDname, Rtype}
 use domain::rdata::AllRecordData;
 use log::{info, trace};
 use odoh_rs::*;
-use rand::prelude::*;
 use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use reqwest::{Client, Url};
 
 type Dname = DnameO<Vec<u8>>;


### PR DESCRIPTION
To make the CLI example buildable i had to perform the included changes. Otherwise, i would get the following error when trying to build with Rust 1.57.0:
```
cargo run --example cli
   Compiling odoh-rs v1.0.0-alpha.1 (odoh-rs)
  --> examples\cli.rs:10:17
   |
10 | use rand::{Rng, SeedableRng};
   |                 ^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

error[E0599]: no function or associated item named `from_entropy` found for struct `StdRng` in the current scope
  --> examples\cli.rs:69:27
   |
69 |     let mut rng = StdRng::from_entropy();
   |                           ^^^^^^^^^^^^ function or associated item not found in `StdRng`

warning: unused import: `Rng`
  --> examples\cli.rs:10:12
   |
10 | use rand::{Rng, SeedableRng};
   |            ^^^

For more information about this error, try `rustc --explain E0599`.
warning: `odoh-rs` (example "cli") generated 2 warnings
error: could not compile `odoh-rs` due to previous error; 2 warnings emitted
'''
