### PR TITLE
example/cli: allow custom headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 anyhow = "1"
-clap = { version = "3.0.0-rc.0", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 criterion = "0.3"
 domain = "0.5"
 env_logger = "0.8"


### PR DESCRIPTION
Extra header could be added in the example client, could useful for
debugging purpose.