### PR TITLE
Bump dependencies (+ refactor a bit)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ categories = ["network-programming", "cryptography"]
 include = ["/src", "/examples", "README.md", "LICENSE"]
 
 [dependencies]
-aes-gcm = { version = "0.8", features = [ "std" ] }
+aes-gcm = { version = "0.10", features = [ "std" ] }
 bytes = "1.0"
-hkdf = "0.10"
-hpke = { version = "0.8", features = [ "std", "x25519" ], default-features = false }
+hkdf = "0.12"
+hpke = { version = "0.9", features = [ "std", "x25519" ], default-features = false }
 rand = { version = "0.8", features = [ "std_rng" ], default-features = false }
 thiserror = "1.0"
 
@@ -22,8 +22,8 @@ thiserror = "1.0"
 anyhow = "1"
 clap = { version = "3.2", features = ["derive"] }
 criterion = "0.3"
-domain = "0.5"
-env_logger = "0.8"
+domain = "0.6"
+env_logger = "0.9"
 hex = "0.4"
 log = "0.4"
 rand = "0.8"

--- a/benches/odoh_bench.rs
+++ b/benches/odoh_bench.rs
@@ -28,7 +28,7 @@ pub fn bench_steps(c: &mut Criterion) {
         b.iter(|| {
             black_box({
                 let query = parse(&mut query_bytes.clone()).unwrap();
-                encrypt_query(&query, key_pair.public(), &mut rng).unwrap();
+                encrypt_query(&query, key_pair.public(), &mut rng).unwrap()
             })
         })
     });
@@ -37,7 +37,7 @@ pub fn bench_steps(c: &mut Criterion) {
         b.iter(|| {
             black_box({
                 let query_enc = parse(&mut query_enc_bytes.clone()).unwrap();
-                decrypt_query(&query_enc, &key_pair).unwrap();
+                decrypt_query(&query_enc, &key_pair).unwrap()
             })
         })
     });
@@ -47,7 +47,7 @@ pub fn bench_steps(c: &mut Criterion) {
             black_box({
                 let nonce = ResponseNonce::default();
                 let response = parse(&mut response_bytes.clone()).unwrap();
-                encrypt_response(&response, &response, srv_secret, nonce).unwrap();
+                encrypt_response(&response, &response, srv_secret, nonce).unwrap()
             })
         })
     });
@@ -56,7 +56,7 @@ pub fn bench_steps(c: &mut Criterion) {
         b.iter(|| {
             black_box({
                 let response_enc = parse(&mut response_enc_bytes.clone()).unwrap();
-                decrypt_response(&query, &response_enc, cli_secret).unwrap();
+                decrypt_response(&query, &response_enc, cli_secret).unwrap()
             })
         })
     });

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,7 @@
 #![deny(missing_docs)]
 
 use aes_gcm::aead::generic_array::GenericArray;
-use aes_gcm::aead::{AeadInPlace, NewAead};
+use aes_gcm::aead::{AeadInPlace, KeyInit};
 use aes_gcm::Aes128Gcm;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use hkdf::Hkdf;
@@ -743,12 +743,12 @@ mod tests {
         // to the clients.
         let public_key = key_pair.public().clone();
         let client_configs: ObliviousDoHConfigs = vec![ObliviousDoHConfig::from(public_key)].into();
-        let client_configs_bytes = compose(&client_configs).unwrap().freeze();
+        let mut client_configs_bytes = compose(&client_configs).unwrap().freeze();
 
         // ... distributing client_configs_bytes ...
 
         // Parse and extract first supported config from client configs on client side.
-        let client_configs: ObliviousDoHConfigs = parse(&mut client_configs_bytes.clone()).unwrap();
+        let client_configs: ObliviousDoHConfigs = parse(&mut client_configs_bytes).unwrap();
         let config_contents = client_configs.supported()[0].clone().into();
 
         // This is a example client request. This library doesn't validate
@@ -883,7 +883,7 @@ mod tests {
             parse::<ObliviousDoHMessagePlaintext, _>(&mut query_bytes.freeze()).unwrap_err()
         );
 
-        let mut query = query.clone();
+        let mut query = query;
         query.padding = vec![1, 2].into();
         assert_eq!(Error::InvalidPadding, compose(&query).unwrap_err());
     }


### PR DESCRIPTION
Hello. First of all, congrats to ODoH as RFC 9230!

This PR is overlapped with #17. But I added additional changes in `src/protocol.rs`, related to `aes_gcm` of version 0.10. So I just made another PR.

I also found that there were some unnecessary `clone()` and semicolons. So I refactor a bit for them.

If you like, could you review this PR and consider to merge it? I am very happy if I could get any response!

Best,
-Jun
