### PR TITLE
example: add option step for debugging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 anyhow = "1"
+base64 = "0.21.0"
 clap = { version = "3.2", features = ["derive"] }
 criterion = "0.3"
 domain = "0.6"


### PR DESCRIPTION
The option can be used to step into the request/response conversation, and let the user take the request to the server and get response back.