### PR TITLE
RUSTSEC-2024-0344: bump hpke to also update curve25519-dalek

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odoh-rs"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Tanya Verma <tverma@cloudflare.com>"]
 edition = "2018"
 license = "BSD-2-Clause"
@@ -14,7 +14,7 @@ include = ["/src", "/examples", "README.md", "LICENSE"]
 aes-gcm = { version = "0.10", features = [ "std" ] }
 bytes = "1.0"
 hkdf = "0.12"
-hpke = { version = "0.10", features = [ "std", "x25519" ], default-features = false }
+hpke = { version = "0.11", features = [ "std", "x25519" ], default-features = false }
 rand = { version = "0.8", features = [ "std_rng" ], default-features = false }
 thiserror = "1.0"
 


### PR DESCRIPTION
Bugfix for https://rustsec.org/advisories/RUSTSEC-2024-0344

hpke=0.10 depends on x25519-dalek=2.0.0-pre.1, so it doesn't upgrade past that